### PR TITLE
Update Node.js version to 22

### DIFF
--- a/custom-sandboxes/amplify-nuxt/Dockerfile
+++ b/custom-sandboxes/amplify-nuxt/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye
+FROM node:22-bullseye
 
 # Install required system dependencies
 RUN apt-get update && apt-get install -y \

--- a/docs/0004-amplify-nuxt-sandbox.md
+++ b/docs/0004-amplify-nuxt-sandbox.md
@@ -5,11 +5,11 @@
 ## 概要
 
 このカスタムサンドボックスは、AWS Amplify と Nuxt.js を使用したTypeScriptベースのアプリケーション開発に特化した環境を提供します。
-OpenHands の推奨イメージ（all-hands/node:16）をベースとし、Node.js アプリケーションの実行環境を構築します。
+Node.js 22 の Debian ベースイメージをベースとし、Node.js アプリケーションの実行環境を構築します。
 
 ## 構成
 
-- ベースイメージ: `all-hands/node:16`
+- ベースイメージ: `node:22-bullseye`
 - 作業ディレクトリ: `/app`
 - 公開ポート: 3000
 - 環境変数:


### PR DESCRIPTION
このPRでは、Amplify Nuxt カスタムサンドボックスの Node.js バージョンを 22 に更新します。

## 変更内容
- ベースイメージを `node:22-bullseye` に更新
- ドキュメントの更新

## 特記事項
- Node.js の最新 LTS バージョンを使用
- Debian ベースのイメージを継続使用